### PR TITLE
add wait process to continue dialog

### DIFF
--- a/BotScaffold/Dialogs/SendMessageDialog.cs
+++ b/BotScaffold/Dialogs/SendMessageDialog.cs
@@ -41,6 +41,7 @@ namespace BotScaffold
 
             var reply = String.Format("Okay I'll send the message \"{0}\" to {1}", message.Entity, contactName.Entity);
             await context.PostAsync(reply);
+            context.Wait(MessageReceived);
         }
     }
 }


### PR DESCRIPTION
We have to add wait process to continue dialog. Please See detail about this.

[Luis Dialog: "exceptionMessage": "invalid need: expected Wait, have Done"](https://github.com/Microsoft/BotBuilder/issues/602)

If we lack it, we face above exception from the second time.
